### PR TITLE
Bumps version of ecto to 2.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Bourne.Mixfile do
   defp applications(_), do: [:ecto, :logger]
 
   defp deps do [
-    {:ecto, "~> 2.0"},
+    {:ecto, "~> 2.1"},
 
     # Testing
     {:postgrex, "~> 0.13", only: [:test]},


### PR DESCRIPTION
Bumps version of Ecto to 2.1 as Ecto streams are introduced in 2.1. Bourne breaks when trying to use Ecto with anything lower as `defoverridable [stream: 1, stream: 2]` errors.